### PR TITLE
Fix issue #83 Unable to find LAN IP on Standalone RPi

### DIFF
--- a/start.py
+++ b/start.py
@@ -271,10 +271,14 @@ def check_root():
     return root
 
 
-def get_lan():
+def get_lan(ip = ""):
     soc = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    dummy_ip = '10.255.255.255'
+    connect_ip = ip if ip else dummy_ip
+
     try:
-        soc.connect(('10.255.255.255', 1))
+        soc.connect((connect_ip, 1))
         lan = str(soc.getsockname()[0])
         soc.close()
     except socket.error:
@@ -397,10 +401,8 @@ def closer(message):
 def default_settings():
     global SETTINGS
 
-    lan_ip = get_lan()
-
     SETTINGS = {
-        "Interface_IP": lan_ip,
+        "Interface_IP": "",
         "Debug": False,
         "DNS": True,
         "HTTP": True,
@@ -410,7 +412,7 @@ def default_settings():
         "Auto_Exploit": "",
         "Auto_Payload": "",
         "DNS_Rules": {
-            "Redirect_IP": lan_ip,
+            "Redirect_IP": "",
             "Redirect": [
                 "the.gate",
                 "www.playstation.com",
@@ -478,14 +480,25 @@ def import_settings(settings_file):
         return
 
     if validate_setting(imported, 'Interface_IP', str):
+        # Try to read Interface_IP from settings.json
         try:
             ipaddress.ip_address(imported['Interface_IP'])
             SETTINGS['Interface_IP'] = imported['Interface_IP']
         except ValueError:
             if imported['Interface_IP'] != '':
-                print('WARNING: "Interface_IP" in settings is not a valid IP, using default')
+                print('WARNING: "Interface_IP" in settings is not a valid IP, attempting to retrieve it')
+
+        # Test IP from settings
+        found_ip = get_lan(SETTINGS['Interface_IP'])
+        if((SETTINGS['Interface_IP']) != '' and (found_ip != SETTINGS['Interface_IP'])):
+            closer('ERROR: Could not connect to "Interface_IP" "{}" (defined in settings), instead discovered IP "{}".'.format(SETTINGS['Interface_IP'], found_ip))
     else:
-        print('WARNING: "Interface_IP" in settings is invalid, using default')
+        print('WARNING: "Interface_IP" in settings not found or invalid, attempting to retrieve it')
+
+    if not SETTINGS['Interface_IP']:
+        # IP address was not set (either not in settings.json or invalid) -> read it from socket
+        lan_ip = get_lan()
+        SETTINGS['Interface_IP'] = lan_ip
 
     if validate_setting(imported, 'Debug', bool):
         SETTINGS['Debug'] = imported['Debug']
@@ -546,8 +559,10 @@ def import_settings(settings_file):
                 ipaddress.ip_address(imported['DNS_Rules']['Redirect_IP'])
                 SETTINGS['DNS_Rules']['Redirect_IP'] = imported['DNS_Rules']['Redirect_IP']
             except ValueError:
-                if imported['DNS_Rules']['Redirect_IP'] != '':
-                    print('WARNING: "DNS_Rules[\'Redirect_IP\']" in settings is not a valid IP, using default')
+                if imported['Interface_IP'] != '':  # Only warn if Interface_IP was NOT auto-discovered
+                    print('WARNING: "DNS_Rules[\'Redirect_IP\']" in settings is {}, using "Interface_IP" instead'.format(("not a valid IP" if imported['DNS_Rules']['Redirect_IP'] != '' else "not set")))
+                SETTINGS['DNS_Rules']['Redirect_IP'] = SETTINGS['Interface_IP']
+        # TODO Validate Redirect_IP if there is one set?
 
         if validate_setting(imported['DNS_Rules'], 'Redirect', list):
             i = 1


### PR DESCRIPTION
- Removed get_lan() from default_settings();
- Instead attempt to use values from settings.json and use get_lan() only if this fails or to test connection.
- Updated get_lan() to get_lan(ip) to make it applicable for testing a given IP