### PR TITLE
Add Binding_Interface_Name setting for multple ethernet adapters

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
     "Debug": false,
     "Root_Check": true,
+    "Bind_Interface_Name": "",
     "DNS": true,
     "HTTP": true,
     "DNS_Interface_IP": "",

--- a/start.py
+++ b/start.py
@@ -410,6 +410,8 @@ def check_root():
 def get_lan():
     ip = ''
     soc = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    if SETTINGS['Bind_Interface_Name']:
+        soc.setsockopt(socket.SOL_SOCKET, 25, str(SETTINGS['Bind_Interface_Name'] + '\0').encode('utf-8'))
 
     try:
         soc.connect(('10.255.255.255', 1))
@@ -535,6 +537,7 @@ def default_settings():
     SETTINGS = {
         "Debug": False,
         "Root_Check": True,
+        "Bind_Interface_Name": "",
         "DNS": True,
         "HTTP": True,
         "DNS_Interface_IP": "",
@@ -619,6 +622,11 @@ def import_settings(settings_file):
         SETTINGS['Root_Check'] = imported['Root_Check']
     else:
         print('WARNING: "Root_Check" in settings is invalid, using default')
+
+    if validate_setting(imported, 'Bind_Interface_Name', str):
+        SETTINGS['Bind_Interface_Name'] = imported['Bind_Interface_Name']
+    else:
+        print('WARNING: "Bind_Interface_Name" in settings is invalid, using default')
 
     if validate_setting(imported, 'DNS', bool):
         SETTINGS['DNS'] = imported['DNS']
@@ -923,6 +931,8 @@ def payload_brain(ipaddr):
 
 def send_payload(hostname, port, timeout, content):
     soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if SETTINGS['Bind_Interface_Name']:
+        soc.setsockopt(socket.SOL_SOCKET, 25, str(SETTINGS['Bind_Interface_Name'] + '\0').encode('utf-8'))
     timeout = time.time() + timeout
     while True:
         result = soc.connect_ex((hostname, port))


### PR DESCRIPTION
Currently this app binds to the first ethernet adapter it finds.  For me this always binds to my VPN tun adapter.  This patch adds a setting to specify the adapter name you want to bind to (ie. 'eth0').

